### PR TITLE
plyalog-clientが無いとビルドを失敗させるスクリプトの追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 2.1.22
+* @akashic/akashic-engine: 2.4.15
+* @akashic/akashic-pdi: 2.4.2
+* @akashic/game-driver: 1.4.14
+* @akashic/pdi-browser: 1.5.14
+* @akashic/playlog-client: 6.0.9
+
+(内部のビルドスクリプトの修正のみ行ったため、 v2.1.21 と同一の内容でpublishしなおしています)
+
 ## 2.1.21
 * @akashic/akashic-engine: 2.4.15
 * @akashic/akashic-pdi: 2.4.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/engine-files",
-  "version": "2.1.21",
+  "version": "2.1.22",
   "description": "A library that manages versions of libraries related to Akashic Engine",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "clean": "shx rm -rf ./dist",
     "build": "npm run clean && npm run build:full && npm run build:canvas && npm run build:gr",
+    "build:require:playlog-client": "shx test -e node_modules/@akashic/playlog-client && npm run build",
     "build:full": "npm run build:full:parts && npm run build:full:zip:debug && npm run build:full:zip:release",
     "build:full:parts": "node build/buildParts full",
     "build:full:zip:debug": "shx cp -r dist/raw/debug/full akashic_engine && zip -r dist/akashic_engine.debug.zip ./akashic_engine && shx rm -r akashic_engine",


### PR DESCRIPTION
### 概要
* 現状playlog-clientが無くてもビルドが成功してしまうのだがその場合成果物の中にplaylog-clientのソースは入らない。
* ビルド生成物の中にplaylog-clientのソースが入っていることを期待する場合があるので、その場合に叩く「plyalog-clientが無いとビルドを失敗させる」スクリプトを追加した。