### PR TITLE
plyalog-clientが無いとビルドを失敗させるスクリプトの追加(v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 1.1.11
+* @akashic/akashic-engine: 1.12.17
+* @akashic/akashic-pdi: 1.10.3
+* @akashic/game-driver: 0.11.22
+* @akashic/pdi-browser: 0.10.19
+* @akashic/playlog-client: 6.0.9
+
+(内部のビルドスクリプトの修正のみなので、v1.1.10 と同一の内容で publish しなおしています)
+
 ## 1.1.10
 * @akashic/akashic-engine: 1.12.17
 * @akashic/akashic-pdi: 1.10.3

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@akashic/engine-files",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "A library that manages versions of libraries related to Akashic Engine",
   "main": "index.js",
   "scripts": {
     "clean": "shx rm -rf ./dist",
     "build": "npm run clean && npm run build:client && npm run build:gr",
+    "build:require:playlog-client": "shx test -e node_modules/@akashic/playlog-client && npm run build",
     "build:client": "npm run build:client:parts && npm run build:client:zip",
     "build:client:parts": "node build/buildParts",
     "build:client:zip": "shx cp -r dist/raw/client/ akashic_engine && zip -r dist/akashic_engine.zip ./akashic_engine && shx rm -r akashic_engine",


### PR DESCRIPTION
### 概要
* 現状playlog-clientが無くてもビルドが成功してしまうのだがその場合成果物の中にplaylog-clientのソースは入らない。
* ビルド生成物の中にplaylog-clientのソースが入っていることを期待する場合があるので、その場合に叩く「plyalog-clientが無いとビルドを失敗させる」スクリプトを追加した。