### PR TITLE
ビルドスクリプトを修正する対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 2.1.32
+* @akashic/akashic-engine: 2.6.0
+* @akashic/akashic-pdi: 2.7.0
+* @akashic/game-driver: 1.7.0
+* @akashic/pdi-browser: 1.8.0
+* @akashic/playlog-client: 7.0.4-alpha.4
+
+(v2.1.31 で壊れていたビルドスクリプトの修正のみ行ったため、 v2.1.31 と同一の内容でpublishしなおしています)
+
 ## 2.1.31
 * @akashic/akashic-engine: 2.6.0
 * @akashic/akashic-pdi: 2.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 * @akashic/akashic-pdi: 2.7.0
 * @akashic/game-driver: 1.7.0
 * @akashic/pdi-browser: 1.8.0
-* @akashic/playlog-client: 7.0.4-alpha.4
+* @akashic/playlog-client: 7.0.5
 
-(v2.1.31 で壊れていたビルドスクリプトの修正のみ行ったため、 v2.1.31 と同一の内容でpublishしなおしています)
+(またv2.1.31 で壊れていたビルドスクリプトの修正も行いました)
 
 ## 2.1.31
 * @akashic/akashic-engine: 2.6.0

--- a/build/buildParts.js
+++ b/build/buildParts.js
@@ -74,12 +74,12 @@ try {
 
 	console.log("build playlog-client");
 	buildPlayLogClient(
-		(packageJson["optionalDependencies"]["@akashic/playlog-client"]).replace(/\./g, "_"),
+		(packageJson["optionalDependencies"]["@akashic/playlog-client"]).replace(/[\.-]/g, "_"),
 		inputDir,
 		path.join(__dirname, "..", "dist", "raw", "release", buildMode)
 	);
 	buildPlayLogClient(
-		(packageJson["optionalDependencies"]["@akashic/playlog-client"]).replace(/\./g, "_"),
+		(packageJson["optionalDependencies"]["@akashic/playlog-client"]).replace(/[\.-]/g, "_"),
 		inputDir,
 		path.join(__dirname, "..", "dist", "raw", "debug", buildMode)
 	);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/engine-files",
-  "version": "2.1.31",
+  "version": "2.1.32",
   "description": "A library that manages versions of libraries related to Akashic Engine",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "uglify-js": "~3.4.6"
   },
   "optionalDependencies": {
-    "@akashic/playlog-client": "7.0.4-alpha.4"
+    "@akashic/playlog-client": "7.0.5"
   },
   "publishConfig": {
     "@akashic:registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
### 概要
* engine-files内のplaylog-clientやakashic-engineのファイル名の`-`を`_`に変換する対応をビルドスクリプトに加えました。`-`が入ってしまうと、ファイル内のグローバル変数がファイル名と同一のものにならないため(browserifyの仕様です)