### PR TITLE
V3 add pdi common impl to grzip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # CHANGELOG
 
 ## 3.0.0-beta.7
-* @akashic/pdi-types: 1.0.1
-* @akashic/pdi-common-impl: 0.0.3
 * @akashic/akashic-engine: 3.0.0-beta.28
 * @akashic/game-driver: 2.0.0-beta.8
+* @akashic/pdi-types: 1.0.1
 * @akashic/pdi-browser: 2.0.0-beta.8
+* @akashic/pdi-common-impl: 0.0.3
 * @akashic/playlog-client: 7.0.32
 
 ## 3.0.0-beta.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 3.0.0-beta.7
+* @akashic/pdi-types: 1.0.1
+* @akashic/pdi-common-impl: 0.0.3
+* @akashic/akashic-engine: 3.0.0-beta.28
+* @akashic/game-driver: 2.0.0-beta.8
+* @akashic/pdi-browser: 2.0.0-beta.8
+* @akashic/playlog-client: 7.0.32
+
 ## 3.0.0-beta.6
 * @akashic/pdi-types: 1.0.0
 * @akashic/akashic-engine: 3.0.0-beta.26

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/engine-files",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0-beta.7",
   "description": "A library that manages versions of libraries related to Akashic Engine",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
     "build:canvas:zip:debug": "shx cp -r dist/raw/debug/canvas akashic_engine && zip -r dist/akashic_engine.canvas.debug.zip ./akashic_engine && shx rm -r akashic_engine",
     "build:canvas:zip:release": "shx cp -r dist/raw/release/canvas akashic_engine && zip -r dist/akashic_engine.canvas.zip ./akashic_engine && shx rm -r akashic_engine",
     "build:gr": "npm run build:gr:parts && npm run build:gr:zip",
-    "build:gr:parts": "shx mkdir -p dist/raw/gr/ && npm run build:gr:ae && npm run build:gr:gdr",
+    "build:gr:parts": "shx mkdir -p dist/raw/gr/ && npm run build:gr:ae && npm run build:gr:gdr && npm run build:gr:pci",
     "build:gr:ae": "browserify -r @akashic/akashic-engine/index.js:@akashic/akashic-engine > dist/raw/gr/akashic-engine.js",
     "build:gr:gdr": "browserify -r @akashic/game-driver -x @akashic/akashic-engine > dist/raw/gr/game-driver.js",
+    "build:gr:pci": "browserify -r @akashic/pdi-common-impl -x @akashic/akashic-engine > dist/raw/gr/pdi-common-impl.js",
     "build:gr:zip": "zip -jr dist/akashic_engine-gr.zip ./dist/raw/gr/",
     "update-modules": "node build/updateInnerModules",
     "update-changelog": "node build/updateChangelog",
@@ -38,12 +39,13 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@akashic/akashic-engine": "3.0.0-beta.26",
+    "@akashic/akashic-engine": "3.0.0-beta.28",
     "@akashic/game-driver": "2.0.0-beta.8",
-    "@akashic/pdi-types": "1.0.0"
+    "@akashic/pdi-types": "1.0.1"
   },
   "devDependencies": {
-    "@akashic/pdi-browser": "2.0.0-beta.7",
+    "@akashic/pdi-browser": "2.0.0-beta.8",
+    "@akashic/pdi-common-impl": "0.0.3",
     "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",


### PR DESCRIPTION
##  概要

`pdi-common-impl` の独立に伴う engine-files のサーバ向け生成ファイルの追従。
- 生成される `akashic_engine-gr.zip` に `pdi-common-impl.js` を追加