### PR TITLE
v2.1.56; remove deprecated that breaks build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.1.56
+dependencies のインストール順でビルドが壊れることがある問題を修正。
+(各モジュールのバージョンは 3.0.18 と同一です)
+
 ## 2.1.55
 * @akashic/akashic-engine: 2.6.6
 * @akashic/akashic-pdi: 2.10.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/engine-files",
-  "version": "2.1.55",
+  "version": "2.1.56",
   "description": "A library that manages versions of libraries related to Akashic Engine",
   "main": "index.js",
   "scripts": {
@@ -44,9 +44,8 @@
   },
   "devDependencies": {
     "@akashic/pdi-browser": "1.11.1",
-    "babel-preset-es2015": "^6.24.1",
-    "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
+    "babel-preset-es2015": "^6.24.1",
     "browserify": "~14.3.0",
     "fs": "~0.0.1-security",
     "npm": "~6.13.4",


### PR DESCRIPTION
#38 の v2 取り込み版です。(不要だった buildParts.js の差分は削っています)
自明につきセルフマージします。
