### PR TITLE
chore: package-lock.json を更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -130,30 +130,30 @@
       }
     },
     "node_modules/@akashic/headless-driver": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@akashic/headless-driver/-/headless-driver-2.1.3.tgz",
-      "integrity": "sha512-CdC4Zqpc1UDjsn74HamwBk5YbStq0pRcP+m6giKSm5HNzYD0ZH/ga8NWNXuVn96xD/6FDizGNcJtdVkVUfmGyA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@akashic/headless-driver/-/headless-driver-2.2.3.tgz",
+      "integrity": "sha512-A9IOUeHzlt3X+eF8WP1pblXYN8Wd30G6kt8hzxVF2TL0xCGeehL2+/WE2WD0GBV56qRtTspUsGovdUvbUCDaKA==",
       "dev": true,
       "dependencies": {
-        "@akashic/amflow": "3.1.0",
-        "@akashic/playlog": "3.1.0",
-        "@akashic/trigger": "1.0.1",
+        "@akashic/amflow": "^3.1.0",
+        "@akashic/playlog": "^3.1.0",
+        "@akashic/trigger": "^1.0.1",
         "aev1": "npm:@akashic/engine-files@1.2.1",
         "aev2": "npm:@akashic/engine-files@2.2.1",
-        "aev3": "npm:@akashic/engine-files@3.2.4",
-        "js-sha256": "0.9.0",
-        "lodash.clonedeep": "4.5.0",
-        "node-fetch": "2.6.7",
-        "vm2": "3.9.10"
+        "aev3": "npm:@akashic/engine-files@3.3.4",
+        "js-sha256": "^0.9.0",
+        "lodash.clonedeep": "^4.5.0",
+        "node-fetch": "^2.6.7",
+        "vm2": "^3.9.11"
       },
       "optionalDependencies": {
-        "canvas": "2.9.3"
+        "canvas": "^2.10.1"
       }
     },
     "node_modules/@akashic/headless-driver/node_modules/canvas": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.9.3.tgz",
-      "integrity": "sha512-WOUM7ghii5TV2rbhaZkh1youv/vW1/Canev6Yx6BG2W+1S07w8jKZqKkPnbiPpQEDsnJdN8ouDd7OvQEGXDcUw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.10.1.tgz",
+      "integrity": "sha512-29pIjn9uwTUsIgJUNd7GXxKk8sg4iyJwLm1wIilNIqX1mVzXSc2nUij9exW1LqNpis1d2ebMYfMqTWcokZ4pdA==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -3735,89 +3735,21 @@
     },
     "node_modules/aev3": {
       "name": "@akashic/engine-files",
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-3.2.4.tgz",
-      "integrity": "sha512-VwXAYH6xbUS1AlNSGdQAERkvXtgJFboPo9L5puR2ZXOHT4yEykn/ApsF48Pi/f7n75PuNoW8RuVobT5fkE4GOA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-3.3.4.tgz",
+      "integrity": "sha512-RoMFZxpFcAKszpIjWdfpMGD6CcXSSazQKCnLiaEKFoI6fF2SKXYTt6pk/+XcvW/GAEv/KbuY+GrI7t5z8fYFTw==",
       "dev": true,
       "dependencies": {
-        "@akashic/akashic-engine": "3.4.4",
+        "@akashic/akashic-engine": "3.6.0",
         "@akashic/amflow": "3.1.0",
         "@akashic/amflow-util": "1.1.0",
-        "@akashic/game-configuration": "1.4.0",
-        "@akashic/game-driver": "2.7.1",
-        "@akashic/pdi-browser": "2.2.3",
+        "@akashic/game-configuration": "1.5.0",
+        "@akashic/game-driver": "2.9.0",
+        "@akashic/pdi-browser": "2.3.2",
         "@akashic/pdi-common-impl": "1.0.0",
-        "@akashic/pdi-types": "1.3.1",
+        "@akashic/pdi-types": "1.4.0",
         "@akashic/playlog": "3.1.0",
         "@akashic/trigger": "1.0.1"
-      }
-    },
-    "node_modules/aev3/node_modules/@akashic/akashic-engine": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-3.4.4.tgz",
-      "integrity": "sha512-458/BbaVeMn7qCl/woq8c4hfoxsTtuGeqqmitFwnug9lcdMvv3HSSdxqye1Gwr7ztW+71hGEeWypM02i6c3prA==",
-      "dev": true,
-      "dependencies": {
-        "@akashic/game-configuration": "~1.4.0",
-        "@akashic/pdi-types": "~1.3.0",
-        "@akashic/playlog": "~3.1.0",
-        "@akashic/trigger": "~1.0.1"
-      }
-    },
-    "node_modules/aev3/node_modules/@akashic/game-configuration": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.4.0.tgz",
-      "integrity": "sha512-AUfpwCKt2wpLzRrTd2l9KdpWNUR/aKyVDsY+9DPmms8kK2TWZ9vALv+FCliJZzf4zzkfswShcdAHQ4yb+YBa5A==",
-      "dev": true,
-      "dependencies": {
-        "@akashic/pdi-types": "~1.3.0"
-      },
-      "optionalDependencies": {
-        "es6-promise": "^4.2.8"
-      }
-    },
-    "node_modules/aev3/node_modules/@akashic/game-driver": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@akashic/game-driver/-/game-driver-2.7.1.tgz",
-      "integrity": "sha512-ttZyFK3REmG2ToKttKB3nA/I/wW3r5W0VxU9bXFJd88zvrInnhE3YXfv1eEe84T2Q+uQ5/FBY9t4ixkLarYmtw==",
-      "dev": true,
-      "dependencies": {
-        "@akashic/akashic-engine": "~3.4.1",
-        "@akashic/amflow-util": "~1.1.0",
-        "@akashic/game-configuration": "~1.3.0",
-        "es6-promise": "^4.2.8"
-      }
-    },
-    "node_modules/aev3/node_modules/@akashic/game-driver/node_modules/@akashic/game-configuration": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.3.0.tgz",
-      "integrity": "sha512-eR4zwuW1ozpAFFtPRQxHykTX4MYNke5k/lWFSY6LzN5qw4U3Pl6tgrHNg1I866R0/B2WUh1N50/hcbKglsyBmQ==",
-      "dev": true,
-      "dependencies": {
-        "@akashic/pdi-types": "~1.3.0"
-      },
-      "optionalDependencies": {
-        "es6-promise": "^4.2.8"
-      }
-    },
-    "node_modules/aev3/node_modules/@akashic/pdi-browser": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@akashic/pdi-browser/-/pdi-browser-2.2.3.tgz",
-      "integrity": "sha512-Z6Y4aj++U88w5J/UegW9Bs2MRWkB9EQzrxcF3QpJJ3l+ZpGg2NNkcVA8lZ6bZld3NJsSHnjNW1dIHIv3BJ+f+g==",
-      "dev": true,
-      "dependencies": {
-        "@akashic/trigger": "~1.0.1"
-      }
-    },
-    "node_modules/aev3/node_modules/@akashic/pdi-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@akashic/pdi-types/-/pdi-types-1.3.1.tgz",
-      "integrity": "sha512-9evGYvwamBRejSnqtPnuf5HNGqofzvQe7qSc+chb4mTq203DSC7ArE4WZ52FuCBHTuxwxB1EpHmLKx1QSX3NAw==",
-      "dev": true,
-      "dependencies": {
-        "@akashic/amflow": "~3.1.0",
-        "@akashic/playlog": "~3.1.0",
-        "@akashic/trigger": "~1.0.1"
       }
     },
     "node_modules/agent-base": {
@@ -13192,9 +13124,9 @@
       }
     },
     "node_modules/vm2": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.10.tgz",
-      "integrity": "sha512-AuECTSvwu2OHLAZYhG716YzwodKCIJxB6u1zG7PgSQwIgAlEaoXH52bxdcvT8GkGjnYK7r7yWDW0m0sOsPuBjQ==",
+      "version": "3.9.11",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.11.tgz",
+      "integrity": "sha512-PFG8iJRSjvvBdisowQ7iVF580DXb1uCIiGaXgm7tynMR1uTBlv7UJlB1zdv5KJ+Tmq1f0Upnj3fayoEOPpCBKg==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.7.0",
@@ -13625,28 +13557,28 @@
       }
     },
     "@akashic/headless-driver": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@akashic/headless-driver/-/headless-driver-2.1.3.tgz",
-      "integrity": "sha512-CdC4Zqpc1UDjsn74HamwBk5YbStq0pRcP+m6giKSm5HNzYD0ZH/ga8NWNXuVn96xD/6FDizGNcJtdVkVUfmGyA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@akashic/headless-driver/-/headless-driver-2.2.3.tgz",
+      "integrity": "sha512-A9IOUeHzlt3X+eF8WP1pblXYN8Wd30G6kt8hzxVF2TL0xCGeehL2+/WE2WD0GBV56qRtTspUsGovdUvbUCDaKA==",
       "dev": true,
       "requires": {
-        "@akashic/amflow": "3.1.0",
-        "@akashic/playlog": "3.1.0",
-        "@akashic/trigger": "1.0.1",
+        "@akashic/amflow": "^3.1.0",
+        "@akashic/playlog": "^3.1.0",
+        "@akashic/trigger": "^1.0.1",
         "aev1": "npm:@akashic/engine-files@1.2.1",
         "aev2": "npm:@akashic/engine-files@2.2.1",
-        "aev3": "npm:@akashic/engine-files@3.2.4",
-        "canvas": "2.9.3",
-        "js-sha256": "0.9.0",
-        "lodash.clonedeep": "4.5.0",
-        "node-fetch": "2.6.7",
-        "vm2": "3.9.10"
+        "aev3": "npm:@akashic/engine-files@3.3.4",
+        "canvas": "^2.10.1",
+        "js-sha256": "^0.9.0",
+        "lodash.clonedeep": "^4.5.0",
+        "node-fetch": "^2.6.7",
+        "vm2": "^3.9.11"
       },
       "dependencies": {
         "canvas": {
-          "version": "2.9.3",
-          "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.9.3.tgz",
-          "integrity": "sha512-WOUM7ghii5TV2rbhaZkh1youv/vW1/Canev6Yx6BG2W+1S07w8jKZqKkPnbiPpQEDsnJdN8ouDd7OvQEGXDcUw==",
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.10.1.tgz",
+          "integrity": "sha512-29pIjn9uwTUsIgJUNd7GXxKk8sg4iyJwLm1wIilNIqX1mVzXSc2nUij9exW1LqNpis1d2ebMYfMqTWcokZ4pdA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -16368,89 +16300,21 @@
       }
     },
     "aev3": {
-      "version": "npm:@akashic/engine-files@3.2.4",
-      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-3.2.4.tgz",
-      "integrity": "sha512-VwXAYH6xbUS1AlNSGdQAERkvXtgJFboPo9L5puR2ZXOHT4yEykn/ApsF48Pi/f7n75PuNoW8RuVobT5fkE4GOA==",
+      "version": "npm:@akashic/engine-files@3.3.4",
+      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-3.3.4.tgz",
+      "integrity": "sha512-RoMFZxpFcAKszpIjWdfpMGD6CcXSSazQKCnLiaEKFoI6fF2SKXYTt6pk/+XcvW/GAEv/KbuY+GrI7t5z8fYFTw==",
       "dev": true,
       "requires": {
-        "@akashic/akashic-engine": "3.4.4",
+        "@akashic/akashic-engine": "3.6.0",
         "@akashic/amflow": "3.1.0",
         "@akashic/amflow-util": "1.1.0",
-        "@akashic/game-configuration": "1.4.0",
-        "@akashic/game-driver": "2.7.1",
-        "@akashic/pdi-browser": "2.2.3",
+        "@akashic/game-configuration": "1.5.0",
+        "@akashic/game-driver": "2.9.0",
+        "@akashic/pdi-browser": "2.3.2",
         "@akashic/pdi-common-impl": "1.0.0",
-        "@akashic/pdi-types": "1.3.1",
+        "@akashic/pdi-types": "1.4.0",
         "@akashic/playlog": "3.1.0",
         "@akashic/trigger": "1.0.1"
-      },
-      "dependencies": {
-        "@akashic/akashic-engine": {
-          "version": "3.4.4",
-          "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-3.4.4.tgz",
-          "integrity": "sha512-458/BbaVeMn7qCl/woq8c4hfoxsTtuGeqqmitFwnug9lcdMvv3HSSdxqye1Gwr7ztW+71hGEeWypM02i6c3prA==",
-          "dev": true,
-          "requires": {
-            "@akashic/game-configuration": "~1.4.0",
-            "@akashic/pdi-types": "~1.3.0",
-            "@akashic/playlog": "~3.1.0",
-            "@akashic/trigger": "~1.0.1"
-          }
-        },
-        "@akashic/game-configuration": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.4.0.tgz",
-          "integrity": "sha512-AUfpwCKt2wpLzRrTd2l9KdpWNUR/aKyVDsY+9DPmms8kK2TWZ9vALv+FCliJZzf4zzkfswShcdAHQ4yb+YBa5A==",
-          "dev": true,
-          "requires": {
-            "@akashic/pdi-types": "~1.3.0",
-            "es6-promise": "^4.2.8"
-          }
-        },
-        "@akashic/game-driver": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/@akashic/game-driver/-/game-driver-2.7.1.tgz",
-          "integrity": "sha512-ttZyFK3REmG2ToKttKB3nA/I/wW3r5W0VxU9bXFJd88zvrInnhE3YXfv1eEe84T2Q+uQ5/FBY9t4ixkLarYmtw==",
-          "dev": true,
-          "requires": {
-            "@akashic/akashic-engine": "~3.4.1",
-            "@akashic/amflow-util": "~1.1.0",
-            "@akashic/game-configuration": "~1.3.0",
-            "es6-promise": "^4.2.8"
-          },
-          "dependencies": {
-            "@akashic/game-configuration": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.3.0.tgz",
-              "integrity": "sha512-eR4zwuW1ozpAFFtPRQxHykTX4MYNke5k/lWFSY6LzN5qw4U3Pl6tgrHNg1I866R0/B2WUh1N50/hcbKglsyBmQ==",
-              "dev": true,
-              "requires": {
-                "@akashic/pdi-types": "~1.3.0",
-                "es6-promise": "^4.2.8"
-              }
-            }
-          }
-        },
-        "@akashic/pdi-browser": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/@akashic/pdi-browser/-/pdi-browser-2.2.3.tgz",
-          "integrity": "sha512-Z6Y4aj++U88w5J/UegW9Bs2MRWkB9EQzrxcF3QpJJ3l+ZpGg2NNkcVA8lZ6bZld3NJsSHnjNW1dIHIv3BJ+f+g==",
-          "dev": true,
-          "requires": {
-            "@akashic/trigger": "~1.0.1"
-          }
-        },
-        "@akashic/pdi-types": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/@akashic/pdi-types/-/pdi-types-1.3.1.tgz",
-          "integrity": "sha512-9evGYvwamBRejSnqtPnuf5HNGqofzvQe7qSc+chb4mTq203DSC7ArE4WZ52FuCBHTuxwxB1EpHmLKx1QSX3NAw==",
-          "dev": true,
-          "requires": {
-            "@akashic/amflow": "~3.1.0",
-            "@akashic/playlog": "~3.1.0",
-            "@akashic/trigger": "~1.0.1"
-          }
-        }
       }
     },
     "agent-base": {
@@ -23262,9 +23126,9 @@
       }
     },
     "vm2": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.10.tgz",
-      "integrity": "sha512-AuECTSvwu2OHLAZYhG716YzwodKCIJxB6u1zG7PgSQwIgAlEaoXH52bxdcvT8GkGjnYK7r7yWDW0m0sOsPuBjQ==",
+      "version": "3.9.11",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.11.tgz",
+      "integrity": "sha512-PFG8iJRSjvvBdisowQ7iVF580DXb1uCIiGaXgm7tynMR1uTBlv7UJlB1zdv5KJ+Tmq1f0Upnj3fayoEOPpCBKg==",
       "dev": true,
       "requires": {
         "acorn": "^8.7.0",


### PR DESCRIPTION
# このPullRequestが解決する内容
`npm audit fix` でセキュリティに問題のある依存モジュールを更新します。
package-lock.json のみの変更のためセルフマージします。

```sh
$ npm audit
# npm audit report

vm2  <3.9.11
Severity: critical
vm2 vulnerable to Sandbox Escape resulting in Remote Code Execution on host - https://github.com/advisories/GHSA-mrgp-mrhc-5jrq
fix available via `npm audit fix`
node_modules/vm2
  @akashic/headless-driver  0.5.12 - 2.2.0
  Depends on vulnerable versions of vm2
  node_modules/@akashic/headless-driver

2 critical severity vulnerabilities
```