### PR TITLE
fix: Canvas 版の成果物の UMD のグローバル変数名がファイル名と異なっていた件を修正 (v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 3.5.1
+* Canvas 版の成果物の UMD のグローバル変数名がファイル名と異なっていた件を修正
+
 ## 3.5.0
 
 * @akashic/akashic-engine: 3.6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/engine-files",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/engine-files",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-engine": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/engine-files",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "A library that manages versions of libraries related to Akashic Engine",
   "main": "index.js",
   "scripts": {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -18,7 +18,7 @@ async function main() {
 
 	await exec(`npx -y browserify ./src/engineFiles.js -t [babelify] -s ${name} -o ./dist/raw/debug/full/${name}.js`, { cwd });
 	await exec(`npx -y uglifyjs ./dist/raw/debug/full/${name}.js --comments -o ./dist/raw/release/full/${name}.js`, { cwd });
-	await exec(`npx -y browserify ./src/engineFiles.canvas.js -t [babelify] -s ${name} -o ./dist/raw/debug/canvas/${name}_Canvas.js`, { cwd });
+	await exec(`npx -y browserify ./src/engineFiles.canvas.js -t [babelify] -s ${name}_Canvas -o ./dist/raw/debug/canvas/${name}_Canvas.js`, { cwd });
 	await exec(`npx -y uglifyjs ./dist/raw/debug/canvas/${name}_Canvas.js --comments -o ./dist/raw/release/canvas/${name}_Canvas.js`, { cwd });
 }
 


### PR DESCRIPTION
# このPullRequestが解決する内容
Canvas 版の成果物の UMD のグローバル変数名がファイル名と異なっていた件を修正します。
`akashic serve` コマンドにて動作確認済みです。

以下のバージョンにおいて誤ったグローバル変数名が指定されていました。

* `3.5.0`
* `3.4.0`
* `3.3.4`
* `3.3.3`
* `3.3.2`
* `3.3.1`
* `3.3.0`
* `3.2.4`
* `3.2.3`
* `3.2.2`
* `3.2.1`