### PR TITLE
Fix set-output command in Actions

### DIFF
--- a/.github/workflows/update_internal_modules.yml
+++ b/.github/workflows/update_internal_modules.yml
@@ -119,7 +119,7 @@ jobs:
         id: variables
         run: |
           NEXT_VERSION=$(cat package.json | jq -r .version)
-          echo "::set-output name=next_version::${NEXT_VERSION}"
+          echo "next_version=${NEXT_VERSION}" >> $GITHUB_OUTPUT
       - name: Create commits
         run: |
           git config user.name 'github-actions'


### PR DESCRIPTION
## 概要

Actions の set-output コマンドが廃止となるため、$GITHUB_OUTPUT を利用するように修正。
[参考ページ](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)