### PR TITLE
chore: bump v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # CHANGELOG
 
-## 2.2.3
+## 2.4.0
 * @akashic/akashic-engine: 2.6.7
-* @akashic/akashic-pdi: 2.11.0
+* @akashic/akashic-pdi: 2.12.0
+* @akashic/amflow: ^3.3.0
+* @akashic/game-driver: 1.11.0
+* @akashic/pdi-browser: 1.12.0
+* @akashic/playlog: ^3.3.0
+
+## 2.3.0
+* @akashic/akashic-engine: 2.6.7
+* @akashic/akashic-pdi: ~2.11.0
 * @akashic/game-driver: 1.11.0
 * @akashic/pdi-browser: 1.12.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
   "name": "@akashic/engine-files",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/engine-files",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-engine": "2.6.7",
-        "@akashic/akashic-pdi": "^2.11.0",
+        "@akashic/akashic-pdi": "2.12.0",
+        "@akashic/amflow": "^3.3.0",
         "@akashic/game-driver": "1.11.0",
-        "@akashic/pdi-browser": "1.12.0"
+        "@akashic/pdi-browser": "1.12.0",
+        "@akashic/playlog": "^3.3.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.17.10",
@@ -38,21 +40,21 @@
       "integrity": "sha512-O6gV2YmMEW1JJTnnztXvUyvyChuKIaHkwNW2DWMHSQQsJWfXRhQ4DghKIlJaczcMWyabNAdJqd+8y24l78kAPQ=="
     },
     "node_modules/@akashic/akashic-pdi": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-pdi/-/akashic-pdi-2.11.0.tgz",
-      "integrity": "sha512-B+PwgtkpH80qEyxO7pOWT6LRTH5o9Yf/hIa1+2riho6LtR/nsiXWleLQKbF6ZMRmUGHzJbsF3g8ZMN57qvj9hQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-pdi/-/akashic-pdi-2.12.0.tgz",
+      "integrity": "sha512-TB3ATn3Q+IZq5ytHNa0f+dbo/XCMrmF9Pi52CRfwN7X2BPb9faSefAyKScg/h+2MSJIUDpsmB/LJ04PXvrw4CQ==",
       "dependencies": {
         "@akashic/akashic-engine": "~2.6.1",
-        "@akashic/amflow": "~3.2.0",
-        "@akashic/playlog": "~3.2.0"
+        "@akashic/amflow": "^3.3.0",
+        "@akashic/playlog": "^3.3.0"
       }
     },
     "node_modules/@akashic/amflow": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@akashic/amflow/-/amflow-3.2.0.tgz",
-      "integrity": "sha512-7FA3BgOouAX9o4WdcQM0kVPUKq9regdeXMiaWtw7ROz9BL8Vve+wyxmWvrE3MQEdpdMGQFb2bG9pNERiNxISNw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@akashic/amflow/-/amflow-3.3.0.tgz",
+      "integrity": "sha512-+dDBtwPfAOeslclGYYKF1yoGg+NiLnDHO3DVIGorkzSd9YLwf+LJGK4sQxRvltKBygmHmhaVrjP7de0PMA+c4Q==",
       "dependencies": {
-        "@akashic/playlog": "~3.2.0"
+        "@akashic/playlog": "~3.3.0"
       }
     },
     "node_modules/@akashic/game-driver": {
@@ -73,9 +75,9 @@
       }
     },
     "node_modules/@akashic/playlog": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@akashic/playlog/-/playlog-3.2.0.tgz",
-      "integrity": "sha512-J9lYTl1P1P6JmYmGMj+mGGgeRl+6o3MjO5iVqcwGSMPmBKUjxLn+BYuLfe5mreFWVobIFnmv65bzZOjzteiOzw=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@akashic/playlog/-/playlog-3.3.0.tgz",
+      "integrity": "sha512-pqX31etu1H9DGvfAuW8w4TiUdcKUUoTBJQd6HF1OZWMDC2O6RSx8DTndYa4Eqr9wll+bs3aRJqUHcVdDJKWevw=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -7778,21 +7780,21 @@
       "integrity": "sha512-O6gV2YmMEW1JJTnnztXvUyvyChuKIaHkwNW2DWMHSQQsJWfXRhQ4DghKIlJaczcMWyabNAdJqd+8y24l78kAPQ=="
     },
     "@akashic/akashic-pdi": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-pdi/-/akashic-pdi-2.11.0.tgz",
-      "integrity": "sha512-B+PwgtkpH80qEyxO7pOWT6LRTH5o9Yf/hIa1+2riho6LtR/nsiXWleLQKbF6ZMRmUGHzJbsF3g8ZMN57qvj9hQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-pdi/-/akashic-pdi-2.12.0.tgz",
+      "integrity": "sha512-TB3ATn3Q+IZq5ytHNa0f+dbo/XCMrmF9Pi52CRfwN7X2BPb9faSefAyKScg/h+2MSJIUDpsmB/LJ04PXvrw4CQ==",
       "requires": {
         "@akashic/akashic-engine": "~2.6.1",
-        "@akashic/amflow": "~3.2.0",
-        "@akashic/playlog": "~3.2.0"
+        "@akashic/amflow": "^3.3.0",
+        "@akashic/playlog": "^3.3.0"
       }
     },
     "@akashic/amflow": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@akashic/amflow/-/amflow-3.2.0.tgz",
-      "integrity": "sha512-7FA3BgOouAX9o4WdcQM0kVPUKq9regdeXMiaWtw7ROz9BL8Vve+wyxmWvrE3MQEdpdMGQFb2bG9pNERiNxISNw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@akashic/amflow/-/amflow-3.3.0.tgz",
+      "integrity": "sha512-+dDBtwPfAOeslclGYYKF1yoGg+NiLnDHO3DVIGorkzSd9YLwf+LJGK4sQxRvltKBygmHmhaVrjP7de0PMA+c4Q==",
       "requires": {
-        "@akashic/playlog": "~3.2.0"
+        "@akashic/playlog": "~3.3.0"
       }
     },
     "@akashic/game-driver": {
@@ -7813,9 +7815,9 @@
       }
     },
     "@akashic/playlog": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@akashic/playlog/-/playlog-3.2.0.tgz",
-      "integrity": "sha512-J9lYTl1P1P6JmYmGMj+mGGgeRl+6o3MjO5iVqcwGSMPmBKUjxLn+BYuLfe5mreFWVobIFnmv65bzZOjzteiOzw=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@akashic/playlog/-/playlog-3.3.0.tgz",
+      "integrity": "sha512-pqX31etu1H9DGvfAuW8w4TiUdcKUUoTBJQd6HF1OZWMDC2O6RSx8DTndYa4Eqr9wll+bs3aRJqUHcVdDJKWevw=="
     },
     "@ampproject/remapping": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/engine-files",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "A library that manages versions of libraries related to Akashic Engine",
   "main": "index.js",
   "scripts": {
@@ -28,9 +28,11 @@
   },
   "dependencies": {
     "@akashic/akashic-engine": "2.6.7",
-    "@akashic/akashic-pdi": "^2.11.0",
+    "@akashic/akashic-pdi": "2.12.0",
+    "@akashic/amflow": "^3.3.0",
     "@akashic/game-driver": "1.11.0",
-    "@akashic/pdi-browser": "1.12.0"
+    "@akashic/pdi-browser": "1.12.0",
+    "@akashic/playlog": "^3.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.10",


### PR DESCRIPTION
掲題通り。

依存系のバージョニングを調整します。

- akashic-pdi: `~` を外してバージョン固定しつつ最新に
- amflow, playlog: `^` つきで導入

engine-files は各依存モジュールのバージョンを定める役割がありますが、 amflow, playlog は以下の背景から実験的に固定しない形で記載します。

- engine-files を複数バージョン抱えるモジュール (e.g. headless-driver) では、その数分の amflow, playlog が入る
  - これは恐らく避けがたい
  - 型の不整合を避けるため、amflow, playlog は全て dedupe される必要がある
- 現状 headless-driver が入れる amflow, playlog のバージョンは engine-files@3 が固定することで定まっている
  - これを 1, 2 系でもバージョン固定すると、amflow, playlog 更新のたびに 3 系統すべて追従が必要になる  (メジャーバージョンが増えれば線形に増える)
- 逆に 1, 2 系で amflow, playlog のバージョンを固定しないと、それらを単独で使う場合にバージョンを確定できなくなるが、もともと型のみのリポジトリである上、通常の semver にしたがってバージョニングしているので、 `^` の範囲で動くのはそこまで問題にならない

修正自体は自明なのでセルフマージします。
