### PR TITLE
Add prepare scripts to package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Prepare
         run: |
           npm ci
-          npm run build
           npm test
       - name: Publish and Release
         uses: akashic-games/action-release@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Run test
         run: |
           npm ci
-          npm run build
           npm test
       - name: Archive artifact
         if: ${{ always() }}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A library that manages versions of libraries related to Akashic Engine",
   "main": "index.js",
   "scripts": {
+    "prepare": "npm run build",
     "build": "rollup -c",
     "update-changelog": "node scripts/updateChangelog.js",
     "update-expected": "ts-node scripts/updateExpected.ts",


### PR DESCRIPTION
## 概要

package.json に ビルドを行う `prepare` スクリプトを追加。
(`npm t` の実行でビルド成果物を参照するため、`npm i` -> `npm t` の流れだとエラーとなる)
