### PR TITLE
revert actions node v18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '18'
           cache: npm
       - name: Prepare
         run: |

--- a/.github/workflows/update_internal_modules.yml
+++ b/.github/workflows/update_internal_modules.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '18'
           cache: npm
       - name: Update akashic-engine
         if: ${{ github.event.inputs.akashic_engine == 'true' }}


### PR DESCRIPTION
## 概要

actions の Node バージョンを 18 -> 22 への更新で publish のCIが node-gyp のインストールで落ちるようになったため、node 18 へ戻します。
自明のためセルフマージします。