### PR TITLE
Update workflows about security

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
     name: Publish and Release
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '18'
           cache: npm
@@ -24,7 +24,7 @@ jobs:
           npm ci
           npm test
       - name: Publish and Release
-        uses: akashic-games/action-release@v2
+        uses: akashic-games/action-release@e4e3c8901b8ed92356c5eb9cf6cfc573a9c4ce9b # v2.1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
       - v1-main
       - v2-main
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -14,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: reftest
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   reftest:
     runs-on: ${{ matrix.os }}
@@ -13,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,14 @@ jobs:
         node: [18.x, 20.x]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: npm
       - name: Set up Homebrew only for macOS
         if: runner.os == 'macOS'
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@5f502512ff94c45bc4122c06677f64ff67d11691 # 2025/09/27時点のmasterブランチ
       - name: brew install only for macOS
         if: runner.os == 'macOS'
         run: |
@@ -31,7 +31,7 @@ jobs:
           npm test
       - name: Archive artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: engine_files_reftest_result_${{ matrix.os }}_${{ matrix.node }}
           path: |

--- a/.github/workflows/update_internal_modules.yml
+++ b/.github/workflows/update_internal_modules.yml
@@ -52,6 +52,10 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update_internal_modules:
     runs-on: ubuntu-latest
@@ -93,7 +97,9 @@ jobs:
         run: npx -y npm-check-updates -f "@akashic/headless-akashic" -u
       - name: Bump Version
         if: ${{ github.event.inputs.version != 'as-is' }}
-        run: npm version ${{ github.event.inputs.version }} --no-git-tag-version
+        run: npm version ${GITHUB_EVENT_INPUTS_VERSION} --no-git-tag-version
+        env:
+          GITHUB_EVENT_INPUTS_VERSION: ${{ github.event.inputs.version }}
       - name: Check Diff
         run: |
           if [ $(git diff --name-only | wc -l) -eq "0" ]; then
@@ -125,7 +131,9 @@ jobs:
           git config user.name 'github-actions'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add -A
-          git commit -m "Update to ${{ steps.variables.outputs.next_version }}"
+          git commit -m "Update to ${STEPS_VARIABLES_OUTPUTS_NEXT_VERSION}"
+        env:
+          STEPS_VARIABLES_OUTPUTS_NEXT_VERSION: ${{ steps.variables.outputs.next_version }}
       - name: Create PullRequest
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:

--- a/.github/workflows/update_internal_modules.yml
+++ b/.github/workflows/update_internal_modules.yml
@@ -57,9 +57,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '18'
           cache: npm
@@ -127,7 +127,7 @@ jobs:
           git add -A
           git commit -m "Update to ${{ steps.variables.outputs.next_version }}"
       - name: Create PullRequest
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           branch-suffix: timestamp
           delete-branch: true


### PR DESCRIPTION
### やったこと
- GithubActionsワークフローのセキュリティ対応
  - 各モジュール使用時にバージョンやタグではなく、SHA PINを指定
    - SHA PINの指定のために、pinactを利用
  - permissionsの指定
  - トークンなしでgit push するワークフロー以外のワークフローで checkout アクションに`persist-credentials: false`追加