### PR TITLE
chore: add devEngines.packageManager to package.json

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node: [18.x, 20.x]
+        node: [24.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/update_internal_modules.yml
+++ b/.github/workflows/update_internal_modules.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: '18'
+          node-version: '24'
           cache: npm
       - name: Update akashic-engine
         if: ${{ github.event.inputs.akashic_engine == 'true' }}

--- a/package.json
+++ b/package.json
@@ -81,5 +81,12 @@
       "<rootDir>/tests/*.spec.ts"
     ],
     "testTimeout": 10000
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.11.0",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
This PR adds `devEngines.packageManager` to package.json to enforce npm version.