### PR TITLE
chore: update package.json devEngines and .npmrc min-release-age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -64,5 +64,12 @@
       "<rootDir>/tests/*.spec.ts"
     ],
     "testTimeout": 10000
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.11.0",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
This PR updates both `package.json` (devEngines.packageManager) and `.npmrc` (min-release-age=7).