### PR TITLE
min-release-age設定追加＋Github Actions ワークフロー更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,30 +7,34 @@ on:
       - v1-main
       - v2-main
 
+env:
+  NODE_VERSION: 24
+
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
     name: Publish and Release
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: '16'
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
-      - name: Use npm@7
-        run: npm i -g npm@7 --registry=https://registry.npmjs.org
       - name: Prepare
         run: |
           npm ci
           npm run build
           npm test
       - name: Publish and Release
-        uses: akashic-games/action-release@v1
+        uses: akashic-games/action-release@a81329f4a70100c4729df80dba17ec8d5da52511 # v3.1.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          npm_token: ${{ secrets.NPM_TOKEN }}
       - name: Upload Artifacts
         working-directory: dist
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,6 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: npm
-      - name: brew install only for macOS
-        if: runner.os == 'macOS'
-        run: |
-          brew install pkg-config cairo pango libpng jpeg giflib librsvg
-          brew install python-setuptools
       - name: Run test
         run: |
           npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: reftest
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   reftest:
     runs-on: ${{ matrix.os }}
@@ -9,16 +12,21 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node: [14.x, 16.x]
+        node: [24.x]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version: ${{ matrix.node }}
           cache: npm
-      - name: Use npm@7
-        run: npm i -g npm@7 --registry=https://registry.npmjs.org
+      - name: brew install only for macOS
+        if: runner.os == 'macOS'
+        run: |
+          brew install pkg-config cairo pango libpng jpeg giflib librsvg
+          brew install python-setuptools
       - name: Run test
         run: |
           npm ci
@@ -26,7 +34,7 @@ jobs:
           npm test
       - name: Archive artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: engine_files_reftest_result
           path: |

--- a/.github/workflows/update_internal_modules.yml
+++ b/.github/workflows/update_internal_modules.yml
@@ -32,16 +32,20 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update_internal_modules:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: '16'
+          node-version: '24'
           cache: npm
       - name: Update akashic-engine
         if: ${{ github.event.inputs.akashic_engine == 'true' }}
@@ -57,7 +61,9 @@ jobs:
         run: npx -y npm-check-updates -f "@akashic/akashic-pdi" -t minor -u
       - name: Bump Version
         if: ${{ github.event.inputs.version != 'as-is' }}
-        run: npm version ${{ github.event.inputs.version }} --no-git-tag-version
+        run: npm version ${GITHUB_EVENT_INPUTS_VERSION} --no-git-tag-version
+        env:
+          GITHUB_EVENT_INPUTS_VERSION: ${{ github.event.inputs.version }}
       - name: Check Diff
         run: |
           if [ $(git diff --name-only | wc -l) -eq "0" ]; then
@@ -84,20 +90,22 @@ jobs:
         run: |
           NEXT_VERSION=$(cat package.json | jq -r .version)
           echo "::set-output name=next_version::${NEXT_VERSION}"
-      - name: Create commits
+      - name: Create Commit and Pull Request
         run: |
+          BRANCH_NAME="update-deps-$(date +%s)"
+          git checkout -b "${BRANCH_NAME}"
           git config user.name 'github-actions'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add -A
-          git commit -m "Update to ${{ steps.variables.outputs.next_version }}"
-      - name: Create PullRequest
-        uses: peter-evans/create-pull-request@v4
-        with:
-          branch-suffix: timestamp
-          delete-branch: true
-          title: 'Update to ${{ steps.variables.outputs.next_version }}'
-          body: |
-            # このPullRequestが解決する内容
-            内部モジュールを更新します。
-          labels: |
-            dependencies
+          git commit -m "Update to ${STEPS_VARIABLES_OUTPUTS_NEXT_VERSION}"
+          git push origin "${BRANCH_NAME}"
+          gh pr create \
+            --title "Update to ${STEPS_VARIABLES_OUTPUTS_NEXT_VERSION}" \
+            --body "$(printf '# このPullRequestが解決する内容\n内部モジュールを更新します。')" \
+            --label "dependencies" \
+            --base "${CURRENT_BRANCH}" \
+            --head "${BRANCH_NAME}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STEPS_VARIABLES_OUTPUTS_NEXT_VERSION: ${{ steps.variables.outputs.next_version }}
+          CURRENT_BRANCH: ${{ github.ref_name }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -64,5 +64,12 @@
       "<rootDir>/tests/*.spec.ts"
     ],
     "testTimeout": 10000
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.11.0",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
### やったこと
- `.npmrc` (`min-release-age=7` 記載)を追加
- `package.json` に `npm@>=11.11.0` でないとnpmコマンドを実行できない設定を追加
- Github Actions ワークフローを以下のように修正(基本的にmain側のワークフローに合わせて修正)
  - Node v24 を利用するように 
  - 各アクションをPINで指定するように
  - permissions の設定
  - npm publish を OIDC 認証で行うように